### PR TITLE
Add Makefile for Laravel Sail Commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: up down build install migrate fresh test npm-install npm-build npm-dev logs ps key
+
+# Start the application
+up:
+	./vendor/bin/sail up -d
+
+# Stop the application
+down:
+	./vendor/bin/sail down
+
+# Build containers
+build:
+	./vendor/bin/sail build
+
+# Install composer dependencies
+install:
+	docker run --rm --interactive --tty \
+		--volume $(PWD):/app \
+		composer install
+
+# Run migrations
+migrate:
+	./vendor/bin/sail artisan migrate
+
+# Install npm dependencies
+npm-install:
+	./vendor/bin/sail npm install
+
+# Build assets
+npm-build:
+	./vendor/bin/sail npm run build
+
+# Run npm dev
+npm-dev:
+	./vendor/bin/sail npm run dev
+
+# View logs
+logs:
+	./vendor/bin/sail logs
+
+# List containers
+ps:
+	./vendor/bin/sail ps
+
+# Generate application key
+key:
+	./vendor/bin/sail artisan key:generate


### PR DESCRIPTION
This PR introduces a Makefile to simplify common Laravel Sail commands, making the development workflow more efficient and easier to remember.

## Changes
- Added a new `Makefile` with the following commands:
  - `make up` - Start the application containers
  - `make down` - Stop the application containers
  - `make build` - Build Docker containers
  - `make install` - Install composer dependencies
  - `make migrate` - Run database migrations
  - `make fresh` - Fresh database migrations
  - `make test` - Run tests
  - `make npm-install` - Install npm dependencies
  - `make npm-build` - Build frontend assets
  - `make npm-dev` - Run Vite development server
  - `make logs` - View container logs
  - `make ps` - List running containers
  - `make key` - Generate application key

## Benefits
- Simplifies development commands
- Reduces typing of long Laravel Sail commands
- Standardizes common development tasks
- Makes onboarding easier for new developers

## How to Test
1. Ensure you have `make` installed on your system
2. Try running various commands like:
   ```bash
   make up
   make install
   make migrate
   ```

## Notes
- All commands are defined as `.PHONY` targets to ensure proper execution
- Commands use Laravel Sail under the hood (`./vendor/bin/sail`)