### PR TITLE
Add Git SHA display in test environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         id: set-tag
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           TAG1="dev"
           TAG2="commit-$SHORT_SHA"
 
@@ -74,3 +75,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ env.SHORT_SHA }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,10 @@ RUN npm run build
 # Production stage
 FROM php:8.4-fpm-alpine
 
+# Add Git SHA as build argument and environment variable
+ARG GIT_SHA
+ENV GIT_SHA=${GIT_SHA}
+
 # Install production dependencies
 RUN apk add --no-cache postgresql-dev
 RUN docker-php-ext-install pdo pdo_pgsql opcache

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -94,5 +94,45 @@
                 </div>
             </main>
         </div>
+
+        @php
+            // Consider both feedback-forms-test and localhost as test environments
+            $appUrl = config('app.url');
+            $isTestEnv = str_contains($appUrl, 'feedback-forms-test') || str_contains($appUrl, 'localhost');
+
+            // Get SHA from environment variable (set during container build)
+            $gitSha = env('GIT_SHA');
+
+            // If we have a full SHA, trim it to short format (7 characters)
+            if ($gitSha && strlen($gitSha) > 7) {
+                $gitSha = substr($gitSha, 0, 7);
+            }
+
+            // Fallback to reading from .git directory only in local development
+            if (!$gitSha && str_contains($appUrl, 'localhost')) {
+                $gitHeadPath = base_path('.git/HEAD');
+                if (file_exists($gitHeadPath)) {
+                    $gitHead = file_get_contents($gitHeadPath);
+                    if (strpos($gitHead, 'ref:') === 0) {
+                        $ref = trim(substr($gitHead, 5));
+                        $gitRefPath = base_path('.git/' . $ref);
+                        if (file_exists($gitRefPath)) {
+                            $gitSha = trim(file_get_contents($gitRefPath));
+                        }
+                    } else {
+                        $gitSha = trim($gitHead);
+                    }
+                    if ($gitSha) {
+                        $gitSha = substr($gitSha, 0, 7); // Short SHA
+                    }
+                }
+            }
+        @endphp
+
+        @if ($isTestEnv && $gitSha)
+            <div class="fixed bottom-2 right-2 bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs px-2 py-1 rounded-md opacity-70">
+                SHA: {{ $gitSha }}
+            </div>
+        @endif
     </body>
 </html>


### PR DESCRIPTION
## Motivation

I want to see the current verision of the image I am testing. A short sha if the container in the right bottom corner in the test and dev environment should be fine.

## Changes

- Update Dockerfile to pass Git SHA as a build argument and environment variable
- Modify GitHub Actions workflow to include Git SHA in build args
- Enhance welcome.blade.php to display short Git SHA in test and local environments

## TODO

- [x] I've assigned myself to this PR