### PR TITLE
fix optional email signup

### DIFF
--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -11,7 +11,7 @@ use Livewire\Volt\Component;
 
 new #[Layout('layouts.guest')] class extends Component {
     public string $name = '';
-    public string $email = '';
+    public ?string $email = null;
     public string $password = '';
     public string $password_confirmation = '';
     public string $register_key = '';
@@ -24,7 +24,7 @@ new #[Layout('layouts.guest')] class extends Component {
     {
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
+            'email' => ['string', 'lowercase', 'email', 'max:255', 'unique:' . User::class, 'nullable'],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
             'register_key' => ['required', 'string', 'max:9', 'min:9', 'exists:registerkeys,code', 'regex:/^[A-Z-0-9]{4}-[A-Z-0-9]{4}$/']
         ], [


### PR DESCRIPTION
## Motivation
When a user doesn't add an email during registration it is saved as an empty string. This conflicts with the unique rule in our user table. This leads that only one user can signup without an email.

## Changes
- make email actually null

## Tests done
- register two users without any email

## TODO

- [x] I've assigned myself to this PR