### PR TITLE
fix aggrgation threshold warning

### DIFF
--- a/app/Livewire/Admin/SurveyAggregation.php
+++ b/app/Livewire/Admin/SurveyAggregation.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Services\SurveyAggregationService;
 use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 /**
@@ -223,6 +224,12 @@ class SurveyAggregation extends Component
         } finally {
             $this->loading = false;
         }
+    }
+
+    #[Computed]
+    public function aviailableValuesById()
+    {
+        return array_flip($this->availableValues);
     }
 
     /**

--- a/resources/views/livewire/admin/survey-aggregation.blade.php
+++ b/resources/views/livewire/admin/survey-aggregation.blade.php
@@ -101,7 +101,7 @@
                     <p class="mt-2 text-yellow-700 dark:text-yellow-300">
                         {{ __('admin.threshold_not_met_description', [
                             'category' => __('admin.' . $aggregatedData['category']),
-                            'value' => $aggregatedData['value'],
+                            'value' => $this->aviailableValuesById[$aggregatedData['value']],
                             'count' => $aggregatedData['submission_count'],
                             'required' => $aggregatedData['min_threshold']
                         ]) }}


### PR DESCRIPTION
## Motivation
The aggregation shows a warning when the survey threshold is not met. Due to normalized values the ids are shown

## Changes
- add computed property that shows name of value

## Tests done
- tested warning

## TODO

- [x] I've assigned myself to this PR