### PR TITLE
FIX: Feedback Counter on Surveys Page

### DIFF
--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -42,6 +42,7 @@ class Feedback extends Model
      */
     protected $appends = [
         'submission_count',
+        'already_answered',
     ];
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Motivation

/surveys page doesn't display the counter correctly currently

## Changes

Changed attributes

## TODO

- [x] I've assigned myself to this PR