### PR TITLE
fix icon centering and increase gap

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -16,8 +16,8 @@
     </head>
     <body class="font-sans text-gray-900 antialiased min-h-dvh">
         <div class="min-h-dvh pt-6 sm:pt-0 bg-gray-100 dark:bg-gray-900 h-full flex flex-col justify-between items-center">
-            <div class="flex flex-col items-center justify-center m-auto gap-4">
-                <a href="/" class="w-20 h-20">
+            <div class="flex flex-col items-center justify-center m-auto gap-8">
+                <a href="/">
                     <x-application-logo class="w-full fill-current text-gray-500" style="margin-inline: auto;height: 100%;width: fit-content;" />
                 </a>
 


### PR DESCRIPTION
## Motivation
The icon on the login and register page is not centered

## Changes
- remove fixed width and height

## Tests done


## TODO

- [x] I've assigned myself to this PR