### PR TITLE
Fix DB Seed

### DIFF
--- a/database/seeders/DepartmentSeeder.php
+++ b/database/seeders/DepartmentSeeder.php
@@ -22,7 +22,7 @@ class DepartmentSeeder extends Seeder
         ];
 
         foreach ($departments as $dept) {
-            Department::updateOrCreate($dept);
+            Department::updateOrCreate(['code' => $dept['code']], $dept);
         }
     }
 }

--- a/database/seeders/GradeLevelsSeeder.php
+++ b/database/seeders/GradeLevelsSeeder.php
@@ -21,7 +21,7 @@ class GradeLevelsSeeder extends Seeder
         ];
 
         foreach ($gradeLevels as $grade) {
-            GradeLevel::UpdateOrcreate($grade);
+            GradeLevel::updateOrCreate(['name' => $grade['name']], $grade);
         }
     }
 }

--- a/database/seeders/SchoolClassSeeder.php
+++ b/database/seeders/SchoolClassSeeder.php
@@ -21,7 +21,7 @@ class SchoolClassSeeder extends Seeder
         ];
 
         foreach ($schoolClasses as $class) {
-            SchoolClass::UpdateOrcreate($class);
+            SchoolClass::updateOrCreate(['name' => $class['name']], $class);
         }
     }
 }

--- a/database/seeders/SchoolYearSeeder.php
+++ b/database/seeders/SchoolYearSeeder.php
@@ -19,7 +19,7 @@ class SchoolYearSeeder extends Seeder
         ];
 
         foreach ($schoolYears as $year) {
-            SchoolYear::create($year);
+            SchoolYear::updateOrCreate(['name' => $year['name']], $year);
         }
     }
 }

--- a/database/seeders/SubjectSeeder.php
+++ b/database/seeders/SubjectSeeder.php
@@ -29,7 +29,7 @@ class SubjectSeeder extends Seeder
         ];
 
         foreach ($subjects as $subject) {
-            Subject::updateOrCreate($subject);
+            Subject::updateOrCreate(['code' => $subject['code']], $subject);
         }
     }
 }


### PR DESCRIPTION
## Motivation

The database seeding process (`php artisan db:seed`), executed by the `db-setup-job.yaml` Kubernetes job during deployment, encountered two issues:

1.  An SQL error occurred in `SurveyResponseSeeder` when run multiple times due to querying a non-existent column (`class` instead of `school_class_id`).
2.  After fixing the SQL error, running the seeder multiple times caused duplicate entries for reference data (Departments, Subjects, etc.) because several seeders were not idempotent.

These issues prevent reliable automated deployments and database setup. This change makes the relevant seeders idempotent, ensuring the `db:seed` command can run safely multiple times without errors or data duplication.

## Changes

*   **`database/seeders/SurveyResponseSeeder.php`**:
    *   Fixed SQL query to use the correct `school_class_id` column instead of `class`.
    *   Added checks to prevent creating duplicate survey responses for feedback that already has results.
*   **`database/seeders/DepartmentSeeder.php`**: Modified to use `updateOrCreate` based on the `code` column.
*   **`database/seeders/GradeLevelsSeeder.php`**: Modified to use `updateOrCreate` based on the `name` column.
*   **`database/seeders/SchoolClassSeeder.php`**: Modified to use `updateOrCreate` based on the `name` column.
*   **`database/seeders/SchoolYearSeeder.php`**: Modified to use `updateOrCreate` based on the `name` column.
*   **`database/seeders/SubjectSeeder.php`**: Modified to use `updateOrCreate` based on the `code` column.
*   **`database/seeders/QuestionSeeder.php`** and **`database/seeders/CheckboxSurveySetupSeeder.php`**: Analyzed and confirmed their existing logic is sufficiently idempotent for their purpose; no changes made.

## TODO

- [x] I've assigned myself to this PR